### PR TITLE
show-options-tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "http://dinofrontend.github.io/dino_ui_library",
   "name": "dino_ui_tools",
-  "version": "1.3.82",
+  "version": "1.3.83",
   "description": "",
   "private": false,
   "main": "dist/index.js",

--- a/src/components/Select/SingleSelect.tsx
+++ b/src/components/Select/SingleSelect.tsx
@@ -14,6 +14,7 @@ import { Loading } from './SharedComponents'
 import { SELECTED_VISIBLE_MIN_COUNT } from './MultiSelect/consts'
 import { TSingleSelectPropTypes } from './types'
 import '../../assets/styles/components/_select.scss'
+import { Tooltip } from '../index'
 
 const SingleSelect = (props: TSingleSelectPropTypes): JSX.Element | null => {
   const {
@@ -40,7 +41,8 @@ const SingleSelect = (props: TSingleSelectPropTypes): JSX.Element | null => {
     labelLeftIconProps,
     labelRightIconComponent,
     optionRightIconComponent,
-    labelAddons
+    labelAddons,
+    showTooltip
   } = props
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -198,6 +200,7 @@ const SingleSelect = (props: TSingleSelectPropTypes): JSX.Element | null => {
                   const isSelected = item.value === currentSelection
                   return (
                     <OptionItem
+                      showTooltip={showTooltip}
                       data={item}
                       key={item.value}
                       onClick={clickHandler(isSelected)}

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -88,6 +88,7 @@ export interface TSingleSelectPropTypes extends IFormCompProps, TSelectBaseProps
   outerHelperText?: string
   innerHelperText?: string
   labelAddons?: JSX.Element
+  showTooltip?:boolean
 }
 
 export type TSelectFooterPropTypes = {

--- a/src/helperComponents/OptionItem/index.tsx
+++ b/src/helperComponents/OptionItem/index.tsx
@@ -1,84 +1,81 @@
-import React, { useCallback } from 'react'
+import React, { useCallback } from 'react';
 
-import { Checkbox } from '../../components/Checkbox'
-import Text from '../../components/Text'
-import { Avatar } from '../../components/Avatar'
-import Icon from '../../components/Icon'
-
-import { TSelectItemProps } from './types'
+import { Checkbox } from '../../components/Checkbox';
+import { Avatar } from '../../components';
+import Icon from '../../components/Icon';
+import { TSelectItemProps } from './types';
+import { Tooltip } from '../../index';
 
 export const OptionItem = (props: TSelectItemProps): JSX.Element => {
-  const {
-    data,
-    onClick,
-    disabled,
-    avatar,
-    isSelected,
-    labelLeftIconProps,
-    LabelRightIconComponent,
-    OptionRightIconComponent,
-    isCheckbox,
-    className = ''
-  } = props
+    const {
+        data,
+        onClick,
+        disabled,
+        avatar,
+        isSelected,
+        labelLeftIconProps,
+        LabelRightIconComponent,
+        OptionRightIconComponent,
+        isCheckbox,
+        className = '',
+        showTooltip = false, // Add withTooltip property with a default value
+    } = props;
 
-  const { label, meta, value } = data
+    const { label, meta, value } = data;
 
-  const handleClick = useCallback(
-    (e: TClickEventType) => {
-      e.preventDefault()
-      e.stopPropagation()
+    const handleClick = useCallback(
+        (e: TClickEventType) => {
+            e.preventDefault();
+            e.stopPropagation();
 
-      if (disabled) {
-        return
-      }
-      onClick({ value, label })
-    },
-    [disabled, value, label, onClick]
-  )
+            if (disabled) {
+                return;
+            }
+            onClick({ value, label });
+        },
+        [disabled, value, label, onClick]
+    );
 
-  return (
-    <div
-      className={`select__option   ${disabled ? 'select__option--disabled' : ''} ${className}`}
-      onClick={handleClick}
-    >
-      {isCheckbox ? (
-        <Checkbox className="mr-8" selectedValue={isSelected} disabled={disabled} />
-      ) : null}
-      {!isCheckbox && isSelected ? (
-        <Icon
-          name="mark"
-          size="xsmall"
-          type={`${disabled ? 'disabled' : 'brand'}`}
-          className="mr-4"
-        />
-      ) : null}
-      <div className="select__option__inner">
-        {avatar ? <Avatar size="xxsmall" imagePath={avatar} className="mr-4" /> : null}
-        {labelLeftIconProps ? (
-          <Icon
-            size="xsmall"
-            type={`${disabled ? 'disabled' : 'primary'}`}
-            className="mr-4 select__left-icon"
-            {...labelLeftIconProps}
-          />
-        ) : null}
-        <div className="select__option__content">
-          <span className={`select__option__text pr-4 ${disabled ? 'color-disabled' : ''}`}>
-            {label}
-          </span>
-          {LabelRightIconComponent && LabelRightIconComponent(value)}
+    const optionContent = (
+        <div
+            id={`${value}`}
+            className={`select__option   ${disabled ? 'select__option--disabled' : ''} ${className}`}
+            onClick={handleClick}
+        >
+            {isCheckbox ? (
+                <Checkbox className="mr-8" selectedValue={isSelected} disabled={disabled} />
+            ) : null}
+            {!isCheckbox && isSelected ? (
+                <Icon name="mark" size="xsmall" type={`${disabled ? 'disabled' : 'brand'}`} className="mr-4" />
+            ) : null}
+            <div className="select__option__inner">
+                {avatar ? <Avatar size="xxsmall" imagePath={avatar} className="mr-4" /> : null}
+                {labelLeftIconProps ? (
+                    <Icon
+                        size="xsmall"
+                        type={`${disabled ? 'disabled' : 'primary'}`}
+                        className="mr-4 select__left-icon"
+                        {...labelLeftIconProps}
+                    />
+                ) : null}
+                <div className="select__option__content">
+                    <span className={`select__option__text pr-4 ${disabled ? 'color-disabled' : ''}`}>{label}</span>
+                    {LabelRightIconComponent && LabelRightIconComponent(value)}
 
-          {meta ? (
-            <Text
-              type="tertiary"
-              className={`select__option__meta ${disabled ? 'color-disabled' : ''}`}
-            >
-              {meta}
-            </Text>
-          ) : null}
+                    {meta ? (
+                        <span className={`select__option__meta ${disabled ? 'color-disabled' : ''}`}>{meta}</span>
+                    ) : null}
+                </div>
+            </div>
+            {OptionRightIconComponent && OptionRightIconComponent(value)}
         </div>
-      </div>
-      {OptionRightIconComponent && OptionRightIconComponent(value)}
-    </div>
-  )
-}
+    );
+
+    return showTooltip ? (
+        <Tooltip position={'middle-right'} text={`${label}`} id={`${value}`}>
+            {optionContent}
+        </Tooltip>
+    ) : (
+        optionContent
+    );
+};

--- a/src/helperComponents/OptionItem/types.ts
+++ b/src/helperComponents/OptionItem/types.ts
@@ -11,4 +11,5 @@ export type TSelectItemProps = {
   avatar?: string
   disabled?: boolean
   isCheckbox?: boolean
+  showTooltip?:boolean
 }

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -50,7 +50,8 @@ export default {
 const OPTIONS: TSelectOptions = [
   {
     value: 1,
-    label: 'Armenia',
+    label:
+      'Armeniaaasdasdasdasdlkashdkjlashdkjasdkjashkdjhaskjdhdaskjdhaskjhdkajsdkjasdkjashdjkashdkjhaskdhaskjdhaskjdhaskjdhaskjhdkjas',
     meta: 'AM'
   },
   {
@@ -196,9 +197,10 @@ const Template = (args: any): JSX.Element => {
   const [selectedValue, setSelectedValue] = useState<TItemValue>(null)
 
   return (
-    <div style={{ width: 320, position: 'absolute', left: 300, top: 100 }}>
+    <div style={{ display: 'flex', height: '100vh', justifyContent: 'center' }}>
       <SelectComp
         {...args}
+        showTooltip={true}
         isRequiredField
         options={OPTIONS}
         outerHelperText="helper text"


### PR DESCRIPTION
Description:

This pull request introduces a new property showTooltip to the OptionItem component, allowing for conditional rendering of the Tooltip based on the presence of this property. The default value for showTooltip is set to false.

Changes:

Added a new property showTooltop to the OptionItem component with a default value of false.
Conditionally wrapped the OptionItem content in a Tooltip based on the value of the withTooltip property.
Usage:

To enable the Tooltip for an OptionItem, set the showTooltop prop to true: