### PR TITLE
Implement Reusable Card Select Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://dinofrontend.github.io/dino_ui_library",
   "name": "dino_ui_tools",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "UI library for Dino",
   "private": false,
   "main": "index.js",

--- a/src/components/CardSelect/CardSelect.tsx
+++ b/src/components/CardSelect/CardSelect.tsx
@@ -35,9 +35,7 @@ export const CardSelect = (props: TCardSelectProps): ReactElement => {
     if (name && setFieldValue) {
       setFieldValue(name, selected, { shouldValidate: true })
     }
-    if (handleChange) {
-      handleChange(selected)
-    }
+    handleChange?.(selected)
   }
 
   const handleCardSelect = () => {

--- a/src/components/CardSelect/CardSelect.tsx
+++ b/src/components/CardSelect/CardSelect.tsx
@@ -2,82 +2,63 @@ import React, { ReactElement } from 'react'
 import { Text } from '../Text'
 import { TCardSelectProps } from './types'
 import classNames from 'classnames'
+import { CardAdditionalInfo, CardChips, CardDescription, CardInput } from './components'
+import { CARD_SELECT_TYPES } from '../../consts'
 import { Radio } from '../Radio'
-import { Input } from '../Input'
-import { Chips } from '../Chips'
-import { Divider } from '../Divider'
+import { Image } from '../Image'
 
 export const CardSelect = (props: TCardSelectProps): ReactElement => {
   const {
-    type,
+    type = CARD_SELECT_TYPES.cardRadio,
     title,
-    badgeText,
     description,
     inputProps,
+    chips = [],
     disabled,
-    className = '',
-    withAction = true,
-    onClick,
-    additionalInfo
+    className,
+    additionalInfo,
+    handleChange,
+    name,
+    setFieldValue,
+    value,
+    cardValue,
+    illustration
   } = props
 
+  const selected = cardValue === value
+
+  const cardSelectStyle = classNames(
+    `card-select card-select--${disabled ? 'disabled' : selected ? 'selected' : null}`,
+    className
+  )
+  const handleCardSelectValue = (selected: number | string) => {
+    if (name && setFieldValue) {
+      setFieldValue(name, selected, { shouldValidate: true })
+    }
+    if (handleChange) {
+      handleChange(selected)
+    }
+  }
+
+  const handleCardSelect = () => {
+    handleCardSelectValue(cardValue)
+  }
+
   return (
-    <div
-      className={classNames(`card-select card-select--${disabled ? 'disabled' : null}`, className)}
-      onClick={onClick}
-    >
+    <div className={cardSelectStyle} onClick={handleCardSelect}>
       <div className="flexbox justify-content--between align-items--start">
         <Text type={disabled ? 'disabled' : 'primary'} size={'medium'} weight={'bold'}>
           <>{title}</>
         </Text>
-
-        {withAction && <Radio disabled={disabled} className={'ml-16'} />}
+        {type === CARD_SELECT_TYPES.cardRadio ? (
+          <Radio name={name} isSelected={selected} disabled={disabled} className={'ml-16'} />
+        ) : null}
       </div>
-
-      {badgeText ? (
-        <Chips
-          color={'brand'}
-          size={'small'}
-          text={badgeText}
-          disabled={disabled}
-          className={'mt-8'}
-        />
-      ) : null}
-
-      {description ? (
-        <Text type={disabled ? 'disabled' : 'secondary'} size={'small'} className={'mt-8'}>
-          <>{description}</>
-        </Text>
-      ) : null}
-
-      {type !== 'simple' ? <Input {...inputProps} className={'mt-16'} disabled={disabled} /> : null}
-
-      {additionalInfo?.length ? (
-        <>
-          <Divider type={'primary'} isHorizontal={true} className={'mt-16 mb-16'} />
-          <div className="card-select__list">
-            {additionalInfo.map((item) => {
-              return (
-                <div
-                  key={item.key}
-                  className="card-select__list__item flexbox justify-content--between mt-12"
-                >
-                  <Text
-                    type={disabled ? 'disabled' : 'secondary'}
-                    size={'small'}
-                    className={'pr-16'}
-                  >
-                    <>{item.key}</>
-                  </Text>
-                  <Text type={disabled ? 'disabled' : 'primary'} weight={'semibold'}>
-                    <>{item.value}</>
-                  </Text>
-                </div>
-              )
-            })}
-          </div>
-        </>
-      ) : null}
+      {illustration ? <Image imagePath={illustration} /> : null}
+      <CardChips chips={chips} disabled={disabled} />
+      <CardDescription description={description} disabled={disabled} />
+      <CardInput inputProps={inputProps} disabled={disabled} />
+      <CardAdditionalInfo additionalInfo={additionalInfo} disabled={disabled} />
     </div>
   )
 }

--- a/src/components/CardSelect/CardSelectGroup.tsx
+++ b/src/components/CardSelect/CardSelectGroup.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { TCardSelectGroupProps } from './types'
+import { CardSelect } from './CardSelect'
+
+export const CardSelectGroup = (props: TCardSelectGroupProps): JSX.Element => {
+  const { cards, name, handleChange, value, cardsGroupType, cardsGroupDisable } = props
+
+  return (
+    <div>
+      {cards.map(
+        (
+          {
+            type,
+            illustration,
+            value: cardValue,
+            title,
+            description,
+            chips,
+            inputProps,
+            additionalInfo,
+            id,
+            disabled
+          },
+          index
+        ) => (
+          <CardSelect
+            className={'mb-20'}
+            name={name}
+            key={id || index}
+            type={cardsGroupType || type}
+            title={title}
+            description={description}
+            chips={chips}
+            inputProps={inputProps}
+            handleChange={handleChange}
+            additionalInfo={additionalInfo}
+            cardValue={cardValue}
+            value={value}
+            illustration={illustration}
+            disabled={cardsGroupDisable || disabled}
+          />
+        )
+      )}
+    </div>
+  )
+}

--- a/src/components/CardSelect/components/CardAdditionalInfo.tsx
+++ b/src/components/CardSelect/components/CardAdditionalInfo.tsx
@@ -13,17 +13,17 @@ export const CardAdditionalInfo = (props: TCardAdditionalInfo): ReactElement | n
     <>
       <Divider type={'primary'} isHorizontal={true} className={'mt-16 mb-16'} />
       <div className="card-select__list">
-        {additionalInfo.map((item) => {
+        {additionalInfo.map(({ key, value, id }) => {
           return (
             <div
-              key={item.key}
+              key={id}
               className="card-select__list__item flexbox justify-content--between mt-12"
             >
               <Text type={disabled ? 'disabled' : 'secondary'} size={'small'} className={'pr-16'}>
-                <>{item.key}</>
+                {key}
               </Text>
               <Text type={disabled ? 'disabled' : 'primary'} weight={'semibold'}>
-                <>{item.value}</>
+                {value}
               </Text>
             </div>
           )

--- a/src/components/CardSelect/components/CardAdditionalInfo.tsx
+++ b/src/components/CardSelect/components/CardAdditionalInfo.tsx
@@ -1,0 +1,34 @@
+import { Divider } from '../../Divider'
+import { Text } from '../../Text'
+import React, { ReactElement } from 'react'
+import { TInfoList } from '../types'
+
+interface TCardAdditionalInfo {
+  additionalInfo?: TInfoList
+  disabled?: boolean
+}
+export const CardAdditionalInfo = (props: TCardAdditionalInfo): ReactElement | null => {
+  const { additionalInfo, disabled } = props
+  return additionalInfo?.length ? (
+    <>
+      <Divider type={'primary'} isHorizontal={true} className={'mt-16 mb-16'} />
+      <div className="card-select__list">
+        {additionalInfo.map((item) => {
+          return (
+            <div
+              key={item.key}
+              className="card-select__list__item flexbox justify-content--between mt-12"
+            >
+              <Text type={disabled ? 'disabled' : 'secondary'} size={'small'} className={'pr-16'}>
+                <>{item.key}</>
+              </Text>
+              <Text type={disabled ? 'disabled' : 'primary'} weight={'semibold'}>
+                <>{item.value}</>
+              </Text>
+            </div>
+          )
+        })}
+      </div>
+    </>
+  ) : null
+}

--- a/src/components/CardSelect/components/CardChips.tsx
+++ b/src/components/CardSelect/components/CardChips.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react'
+import { Chips } from '../../Chips'
+import { TChipsProps } from '../../Chips/types'
+
+interface TCardChips {
+  chips: TChipsProps[]
+  disabled?: boolean
+}
+export const CardChips = (props: TCardChips): ReactElement => {
+  const { chips, disabled } = props
+  return (
+    <>
+      {chips.map((chip, index) => (
+        <Chips
+          {...chip}
+          key={index}
+          disabled={disabled}
+          className={'mt-8 mr-8'}
+          onClick={chip.onClick}
+          withAction={chip.withAction}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/components/CardSelect/components/CardChips.tsx
+++ b/src/components/CardSelect/components/CardChips.tsx
@@ -10,10 +10,10 @@ export const CardChips = (props: TCardChips): ReactElement => {
   const { chips, disabled } = props
   return (
     <>
-      {chips.map((chip, index) => (
+      {chips.map((chip) => (
         <Chips
           {...chip}
-          key={index}
+          key={chip.id}
           disabled={disabled}
           className={'mt-8 mr-8'}
           onClick={chip.onClick}

--- a/src/components/CardSelect/components/CardDescription.tsx
+++ b/src/components/CardSelect/components/CardDescription.tsx
@@ -1,0 +1,15 @@
+import React, { ReactElement } from 'react'
+import { Text } from '../../Text'
+
+interface TCardDescription {
+  description?: string
+  disabled?: boolean
+}
+export const CardDescription = (props: TCardDescription): ReactElement | null => {
+  const { description, disabled } = props
+  return description ? (
+    <Text type={disabled ? 'disabled' : 'secondary'} size={'small'} className={'mt-8'}>
+      <>{description}</>
+    </Text>
+  ) : null
+}

--- a/src/components/CardSelect/components/CardInput.tsx
+++ b/src/components/CardSelect/components/CardInput.tsx
@@ -1,0 +1,17 @@
+import React, { ReactElement } from 'react'
+import { InputCustomProps } from '../../Input/types'
+import { Input } from '../../Input'
+
+interface TCardInput {
+  inputProps?: InputCustomProps
+  disabled?: boolean
+  className?: string
+}
+export const CardInput = (props: TCardInput): ReactElement => {
+  const { inputProps, disabled, className } = props
+  return (
+    <div className={className}>
+      {inputProps ? <Input {...inputProps} className={'mt-16'} disabled={disabled} /> : null}
+    </div>
+  )
+}

--- a/src/components/CardSelect/components/CardInput.tsx
+++ b/src/components/CardSelect/components/CardInput.tsx
@@ -5,13 +5,8 @@ import { Input } from '../../Input'
 interface TCardInput {
   inputProps?: InputCustomProps
   disabled?: boolean
-  className?: string
 }
-export const CardInput = (props: TCardInput): ReactElement => {
-  const { inputProps, disabled, className } = props
-  return (
-    <div className={className}>
-      {inputProps ? <Input {...inputProps} className={'mt-16'} disabled={disabled} /> : null}
-    </div>
-  )
+export const CardInput = (props: TCardInput): ReactElement | null => {
+  const { inputProps, disabled } = props
+  return inputProps ? <Input {...inputProps} className={'mt-16'} disabled={disabled} /> : null
 }

--- a/src/components/CardSelect/components/index.ts
+++ b/src/components/CardSelect/components/index.ts
@@ -1,0 +1,4 @@
+export { CardChips } from './CardChips'
+export { CardInput } from './CardInput'
+export { CardDescription } from './CardDescription'
+export { CardAdditionalInfo } from './CardAdditionalInfo'

--- a/src/components/CardSelect/index.ts
+++ b/src/components/CardSelect/index.ts
@@ -1,1 +1,2 @@
-export * from './CardSelect'
+export { CardSelect } from './CardSelect'
+export { CardSelectGroup } from './CardSelectGroup'

--- a/src/components/CardSelect/types.ts
+++ b/src/components/CardSelect/types.ts
@@ -3,7 +3,7 @@ import { TChipsProps } from '../Chips/types'
 import { CARD_SELECT_TYPES } from '../../consts'
 export interface TCardSelectProps extends IFormCompProps {
   id?: number | string
-  type?: CARD_SELECT_TYPES.card | CARD_SELECT_TYPES.cardRadio
+  type?: CARD_SELECT_TYPES
   title: string
   description: string
   chips: TChipsProps[]
@@ -24,9 +24,8 @@ export interface TCardSelectGroupProps extends IFormCompProps {
   cards: TCardSelectProps[]
   handleChange?: (selected: number | string) => void
   value: number | string
-  cardsGroupDisable?:boolean
-  cardsGroupType?: CARD_SELECT_TYPES.card | CARD_SELECT_TYPES.cardRadio
-
+  cardsGroupDisable?: boolean
+  cardsGroupType?: CARD_SELECT_TYPES
 }
 
 export type TInfoList = TInfoListItem[]
@@ -34,4 +33,5 @@ export type TInfoList = TInfoListItem[]
 export type TInfoListItem = {
   key: string
   value: string
+  id?: number | string
 }

--- a/src/components/CardSelect/types.ts
+++ b/src/components/CardSelect/types.ts
@@ -1,18 +1,32 @@
-import { ReactNode } from 'react'
 import { InputCustomProps } from '../Input/types'
-
-export interface TCardSelectProps {
-  type: string | 'simple'
-  title: string | ReactNode
-  description: string | ReactNode
-  badgeText: string | ReactNode
-  inputProps: InputCustomProps
+import { TChipsProps } from '../Chips/types'
+import { CARD_SELECT_TYPES } from '../../consts'
+export interface TCardSelectProps extends IFormCompProps {
+  id?: number | string
+  type?: CARD_SELECT_TYPES.card | CARD_SELECT_TYPES.cardRadio
+  title: string
+  description: string
+  chips: TChipsProps[]
+  inputProps?: InputCustomProps
   className?: string
   disabled?: boolean
-  withAction?: boolean
-  onClick?: (e: TClickEventType) => void
+  handleCardSelectValue?: (isChecked: boolean) => void
   dataId?: string
   additionalInfo?: TInfoList
+  selectedCard?: number
+  value: number | string
+  handleChange?: (selected: number | string) => void
+  isSelected?: boolean
+  cardValue: number | string
+  illustration?: string
+}
+export interface TCardSelectGroupProps extends IFormCompProps {
+  cards: TCardSelectProps[]
+  handleChange?: (selected: number | string) => void
+  value: number | string
+  cardsGroupDisable?:boolean
+  cardsGroupType?: CARD_SELECT_TYPES.card | CARD_SELECT_TYPES.cardRadio
+
 }
 
 export type TInfoList = TInfoListItem[]

--- a/src/components/Chips/Chips.tsx
+++ b/src/components/Chips/Chips.tsx
@@ -26,6 +26,12 @@ export const Chips = (props: TChipsProps): ReactElement => {
 
   const customType = disabled ? 'disabled' : type == 'filled' ? 'inverse' : color
 
+  const handleClick = (event: TClickEventType) => {
+    event.stopPropagation()
+    if (onClick) {
+      onClick(event)
+    }
+  }
   return (
     <div
       className={classNames(
@@ -56,7 +62,7 @@ export const Chips = (props: TChipsProps): ReactElement => {
           size={ChipsActionIconSize[size]}
           type={customType}
           className="chips__delete"
-          onClick={onClick}
+          onClick={handleClick}
         />
       )}
     </div>

--- a/src/components/Chips/Chips.tsx
+++ b/src/components/Chips/Chips.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import { Icon } from '../Icon'
 import { Text } from '../Text'
-import { TChipsProps } from './types'
+import { ChipCustomType, TChipsProps } from './types'
 import classNames from 'classnames'
 
 enum ChipsActionIconSize {
@@ -24,13 +24,15 @@ export const Chips = (props: TChipsProps): ReactElement => {
     dataId = ''
   } = props
 
-  const customType = disabled ? 'disabled' : type == 'filled' ? 'inverse' : color
+  const customType = disabled
+    ? 'disabled'
+    : type == ChipCustomType.filled
+      ? ChipCustomType.inverse
+      : color
 
   const handleClick = (event: TClickEventType) => {
     event.stopPropagation()
-    if (onClick) {
-      onClick(event)
-    }
+    onClick?.(event)
   }
   return (
     <div

--- a/src/components/Chips/types.ts
+++ b/src/components/Chips/types.ts
@@ -21,4 +21,10 @@ export interface TChipsProps extends IFormCompProps {
   withAction?: boolean
   onClick?: (e: TClickEventType) => void
   dataId?: string
+  id?: string | number
+}
+
+export enum ChipCustomType {
+  filled = 'filled',
+  inverse = 'inverse',
 }

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -25,7 +25,7 @@ export enum FILE_UPLOAD_ERRORS {
 
 export enum CARD_SELECT_TYPES {
   cardRadio = 'cardRadio',
-  card = 'card',
+  card = 'card'
 }
 
 export const CUSTOM_SCROLL_MESSAGE = 'Custom scroll event has fired'

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -23,6 +23,11 @@ export enum FILE_UPLOAD_ERRORS {
   'type'
 }
 
+export enum CARD_SELECT_TYPES {
+  cardRadio = 'cardRadio',
+  card = 'card',
+}
+
 export const CUSTOM_SCROLL_MESSAGE = 'Custom scroll event has fired'
 export const CUSTOM_SCROLL_NAME = 'CUSTOM_SCROLL_EVENT'
 

--- a/src/stories/CardSelect.stories.tsx
+++ b/src/stories/CardSelect.stories.tsx
@@ -145,7 +145,7 @@ CardSelect.args = {
     {
       text: 'Chip 1',
       color: 'success',
-      type: 'filled',
+      type: 'filled'
     },
     {
       text: 'Chip 2',

--- a/src/stories/CardSelect.stories.tsx
+++ b/src/stories/CardSelect.stories.tsx
@@ -1,24 +1,62 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { CardSelectGroup as _CardSelectGroup } from '../components/CardSelect'
 import { CardSelect as _CardSelect } from '../components/CardSelect'
 import { Popover } from '../components/Popover'
 import { Icon } from '../components/Icon'
+import { CARD_SELECT_TYPES } from '../consts'
 
 export default {
   title: 'CardSelect',
-  component: _CardSelect,
+  component: _CardSelectGroup,
   argTypes: {
-    type: {
-      options: ['', 'simple'],
+    cardsGroupType: {
+      options: [CARD_SELECT_TYPES.cardRadio, CARD_SELECT_TYPES.card],
+      control: { type: 'radio' }
+    },
+    cardsGroupDisable: {
+      options: [true, false],
       control: { type: 'radio' }
     }
   }
 }
 
-const Template = (args) => (
-  <_CardSelect
-    {...args}
-    inputProps={{
+const CARDS = [
+  {
+    title: 'Card Select',
+    chips: [
+      {
+        text: 'Chip 1',
+        color: 'success',
+        type: 'filled'
+      },
+      {
+        text: 'Chip 2',
+        color: 'warning',
+        type: 'filled'
+      }
+    ],
+    description:
+      "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's " +
+      'standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. ',
+    badgeText: 'Badge',
+    disabled: false,
+    withAction: true,
+    additionalInfo: [
+      {
+        key: 'Key 1',
+        value: 'Value 1'
+      },
+      {
+        key: 'Key 2',
+        value: 'Value 2'
+      }
+    ],
+    inputProps: {
+      name: 'input 1',
       label: 'Label',
+      handleChange: (e) => {
+        console.log(e)
+      },
       labelAddons: (
         <Popover
           linkAddons={{ url: 'link', beforeLink: 'text before link' }}
@@ -31,15 +69,90 @@ const Template = (args) => (
           </div>
         </Popover>
       )
-    }}
-  />
-)
+    },
+    onClick: (e: any) => {
+      console.log(e)
+    },
+    value: 1
+  },
+  {
+    value: 2,
+    title: 'Card Select 2',
+    chips: [
+      {
+        text: 'Chip 1',
+        color: 'success',
+        type: 'filled'
+      },
+      {
+        text: 'Chip 2',
+        color: 'warning',
+        type: 'filled'
+      }
+    ],
+    description:
+      "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's " +
+      'standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. ',
+    badgeText: 'Badge',
+    disabled: false,
+    withAction: true,
+    additionalInfo: [
+      {
+        key: 'Key 1',
+        value: 'Value 1'
+      },
+      {
+        key: 'Key 2',
+        value: 'Value 2'
+      }
+    ],
+    inputProps: {
+      label: 'Label',
+      name: 'input 2',
+      labelAddons: (
+        <Popover
+          linkAddons={{ url: 'link', beforeLink: 'text before link' }}
+          id="beneficiary-tooltip"
+          text={'data'}
+          position="top-center"
+        >
+          <div id="beneficiary-tooltip">
+            <Icon name="info" type="information" size="xsmall" className={'ml-4 pointer'} />
+          </div>
+        </Popover>
+      )
+    },
+    onClick: (e: any) => {
+      console.log(e)
+    }
+  }
+]
+
+const Template = (args) => {
+  return (
+    <div style={{ width: '50%' }}>
+      <_CardSelect {...args} />
+    </div>
+  )
+}
 
 export const CardSelect = Template.bind({})
 
 CardSelect.args = {
-  type: '',
+  type: CARD_SELECT_TYPES.card,
   title: 'Card Select',
+  chips: [
+    {
+      text: 'Chip 1',
+      color: 'success',
+      type: 'filled',
+    },
+    {
+      text: 'Chip 2',
+      color: 'warning',
+      type: 'filled'
+    }
+  ],
   description:
     "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's " +
     'standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. ',
@@ -55,5 +168,19 @@ CardSelect.args = {
       key: 'Key 2',
       value: 'Value 2'
     }
-  ]
+  ],
+  onClick: (e: any) => {
+    console.log(e)
+  }
 }
+
+const CardSelectGroupTemplate = (args) => {
+  const [selected, setSelected] = useState(null)
+  return (
+    <div style={{ width: '50%' }}>
+      <_CardSelectGroup {...args} cards={CARDS} value={selected} handleChange={setSelected} />
+    </div>
+  )
+}
+
+export const CardSelectGroup = CardSelectGroupTemplate.bind({})


### PR DESCRIPTION
This pull request introduces a new reusable CardSelect component for enhanced user interaction and data selection within our application.

1. **Flexibility**: Supports various card selection types (radio buttons for single selection, potentially checkboxes for multiple selections in the future).
2. **Data-Driven**: Accepts props like title, description, illustration, chips, and inputProps for dynamic content display.
3. **Accessibility**: Handles disabled states for visual clarity and appropriate interaction.
4. **Integration**: Works seamlessly with form management libraries by receiving value changes through handleChange and name props (example using setFieldValue for formik integration).